### PR TITLE
fix: status payment capture and fail

### DIFF
--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -90,6 +90,7 @@ class CheckoutController extends BaseController {
 
             switch ($status) {
                 case 'settlement':
+                case 'capture':
                     $transaction->update([
                         'type'   => strtoupper($payload['payment_type']),
                         'method' => strtoupper($payload['bank'] ?? ''),
@@ -135,6 +136,13 @@ class CheckoutController extends BaseController {
                 case 'deny':
                     $transaction->update([
                         'status' => 'DENIED'
+                    ]);
+                    $this->returnVoucherIfAny($transaction->id);
+                    break;
+
+                case 'failure':
+                    $transaction->update([
+                        'status' => 'FAILED'
                     ]);
                     $this->returnVoucherIfAny($transaction->id);
                     break;

--- a/resources/views/bootstrap/transaction-detail.blade.php
+++ b/resources/views/bootstrap/transaction-detail.blade.php
@@ -50,7 +50,7 @@
                     <span class="status-badge status-pending">AWAITING PAYMENT</span>
                 @elseif($transaction->status == 'SETTLED' || $transaction->status == 'PAID' || $transaction->status == 'SUCCESS')
                     <span class="status-badge status-paid">SUCCESS</span>
-                @elseif($transaction->status == 'EXPIRED' || $transaction->status == 'CANCELLED' || $transaction->status == 'REFUNDED')
+                @elseif($transaction->status == 'EXPIRED' || $transaction->status == 'CANCELLED' || $transaction->status == 'REFUNDED' || $transaction->status == 'FAILED')
                     <span class="status-badge status-expired">{{ $transaction->status }}</span>
                 @elseif($transaction->status == 'COMPLETED')
                     <span class="status-badge status-completed">COMPLETED</span>

--- a/resources/views/display-store/customer/transaction.blade.php
+++ b/resources/views/display-store/customer/transaction.blade.php
@@ -25,7 +25,7 @@
                 <div class="chip paid">
                     <div class="chip-content">SUCCESS</div>
                 </div>
-                @elseif($transaction->status == 'EXPIRED' || $transaction->status == 'CANCELLED' || $transaction->status == 'REFUNDED')
+                @elseif($transaction->status == 'EXPIRED' || $transaction->status == 'CANCELLED' || $transaction->status == 'REFUNDED' || $transaction->status == 'FAILED')
                 <div class="chip expired">
                     <div class="chip-content">{{ $transaction->status }}</div>
                 </div>


### PR DESCRIPTION
Changelog:
- add status CAPTURE to midtrans webhook (set as success)
- add unhanded status FAILURE from midtrans
- show status FAILED on user dashboard